### PR TITLE
Enable customizable styling

### DIFF
--- a/src/components/Details/DetailsComponent.js
+++ b/src/components/Details/DetailsComponent.js
@@ -133,10 +133,22 @@ class Details extends React.Component {
     this.props.dispatch({ type: ACTIONS.UPDATE_GRAPH_STYLES, payload: { nodeStyles: updatedStyles } });
   }
 
+  handleEdgeStyleChange(index, field, value) {
+    const updatedStyles = [...this.props.graphStyles.edgeStyles];
+    updatedStyles[index][field] = value;
+    this.props.dispatch({ type: ACTIONS.UPDATE_GRAPH_STYLES, payload: { edgeStyles: updatedStyles } });
+  }
+
   addNodeStyle = () => {
-    const newStyle = { property: '', value: '', color: '#000000' };
+    const newStyle = { property: '', value: '', color: '#000000', shape: 'dot', size: 25 };
     const updatedStyles = [...this.props.graphStyles.nodeStyles, newStyle];
     this.props.dispatch({ type: ACTIONS.UPDATE_GRAPH_STYLES, payload: { nodeStyles: updatedStyles } });
+  }
+
+  addEdgeStyle = () => {
+    const newStyle = { property: '', value: '', color: '#848484', width: 1, dashes: false };
+    const updatedStyles = [...this.props.graphStyles.edgeStyles, newStyle];
+    this.props.dispatch({ type: ACTIONS.UPDATE_GRAPH_STYLES, payload: { edgeStyles: updatedStyles } });
   }
 
   render(){
@@ -263,6 +275,17 @@ class Details extends React.Component {
                           value={style.value}
                           onChange={(e) => this.handleNodeStyleChange(index, 'value', e.target.value)}
                         />
+                        <TextField
+                          label="Shape"
+                          value={style.shape}
+                          onChange={(e) => this.handleNodeStyleChange(index, 'shape', e.target.value)}
+                        />
+                        <TextField
+                          label="Size"
+                          type="number"
+                          value={style.size}
+                          onChange={(e) => this.handleNodeStyleChange(index, 'size', e.target.value)}
+                        />
                         <SketchPicker
                           color={style.color}
                           onChange={(color) => this.handleNodeStyleChange(index, 'color', color.hex)}
@@ -270,6 +293,44 @@ class Details extends React.Component {
                       </div>
                     ))}
                     <Button onClick={this.addNodeStyle}>Add Node Style</Button>
+                  </Grid>
+                  <Grid item xs={12}>
+                    <Typography variant="h6">Edge Styles</Typography>
+                    {this.props.graphStyles.edgeStyles.map((style, index) => (
+                      <div key={index}>
+                        <TextField
+                          label="Property"
+                          value={style.property}
+                          onChange={(e) => this.handleEdgeStyleChange(index, 'property', e.target.value)}
+                        />
+                        <TextField
+                          label="Value"
+                          value={style.value}
+                          onChange={(e) => this.handleEdgeStyleChange(index, 'value', e.target.value)}
+                        />
+                        <TextField
+                          label="Width"
+                          type="number"
+                          value={style.width}
+                          onChange={(e) => this.handleEdgeStyleChange(index, 'width', e.target.value)}
+                        />
+                        <FormControlLabel
+                          control={
+                            <Switch
+                              checked={style.dashes}
+                              onChange={(e) => this.handleEdgeStyleChange(index, 'dashes', e.target.checked)}
+                              color="primary"
+                            />
+                          }
+                          label="Dashes"
+                        />
+                        <SketchPicker
+                          color={style.color}
+                          onChange={(color) => this.handleEdgeStyleChange(index, 'color', color.hex)}
+                        />
+                      </div>
+                    ))}
+                    <Button onClick={this.addEdgeStyle}>Add Edge Style</Button>
                   </Grid>
                 </Grid>
               </ExpansionPanelDetails>

--- a/src/components/NetworkGraph/NetworkGraphComponent.js
+++ b/src/components/NetworkGraph/NetworkGraphComponent.js
@@ -51,6 +51,43 @@ class NetworkGraph extends React.Component {
     });
 
     this.props.dispatch({ type: ACTIONS.SET_NETWORK, payload: network });
+    this.applyGraphStyles();
+  }
+
+  componentDidUpdate() {
+    this.applyGraphStyles();
+  }
+
+  applyGraphStyles() {
+    const { nodeStyles, edgeStyles, defaultNodeColor, defaultEdgeColor } = this.props.graphStyles;
+
+    this.props.nodeHolder.forEach((node) => {
+      let update = { color: { background: defaultNodeColor } };
+      nodeStyles.forEach(style => {
+        if (node.properties && String(node.properties[style.property]) === style.value) {
+          update = {
+            color: { background: style.color },
+            shape: style.shape,
+            size: Number(style.size)
+          };
+        }
+      });
+      this.props.nodeHolder.update({ id: node.id, ...update });
+    });
+
+    this.props.edgeHolder.forEach((edge) => {
+      let update = { color: { color: defaultEdgeColor } };
+      edgeStyles.forEach(style => {
+        if (edge.properties && String(edge.properties[style.property]) === style.value) {
+          update = {
+            color: { color: style.color },
+            width: Number(style.width),
+            dashes: style.dashes
+          };
+        }
+      });
+      this.props.edgeHolder.update({ id: edge.id, ...update });
+    });
   }
 
   handleContextMenuClose = () => {

--- a/src/reducers/optionReducer.js
+++ b/src/reducers/optionReducer.js
@@ -83,6 +83,15 @@ export const reducer = function optionReducer(state = initialState, action) {
         }
       };
 
+    case ACTIONS.UPDATE_GRAPH_STYLES:
+      return {
+        ...state,
+        graphStyles: {
+          ...state.graphStyles,
+          ...action.payload
+        }
+      };
+
     default:
       return state;
   }


### PR DESCRIPTION
## Summary
- extend graph styling capabilities
- allow defining node and edge styling rules
- apply styling rules dynamically in the network graph
- store styling options in reducer

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c47f701e8832cb308370e3fa51bae